### PR TITLE
docs: add frontmatter description for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: WAF
+description: Web application firewall configuration and policies for F5 Distributed Cloud.
 hero:
   tagline: Web application firewall configuration and policies.
   image:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+line-length = 88
+
+[format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
## Summary

- Adds a `description:` field to `docs/index.mdx` frontmatter so the starlight-llms-txt plugin includes page-level metadata in the llms.txt output

Refs f5xc-salesdemos/xcsh#223

Step 5c of the cascading llms.txt knowledge hierarchy -- adds a `description:` field to the index page frontmatter so the starlight-llms-txt plugin can include it in the llms.txt output.

Closes #279

## Test plan

- [ ] CI checks pass
- [ ] Verify the `description` field appears in the frontmatter of `docs/index.mdx`
- [ ] Confirm the starlight-llms-txt plugin picks up the description in llms.txt output after deploy