### PR TITLE
i18n: re-translate all locales with glossary-enforced product terms

### DIFF
--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: جدار حماية تطبيقات الويب
-description: تكوين وسياسات جدار حماية تطبيقات الويب لسحابة F5 الموزعة.
+title: WAF
+description: تكوين جدار حماية تطبيقات الويب (WAF) والسياسات الخاصة بـ F5 Distributed Cloud.
 hero:
-  tagline: تكوين وسياسات جدار حماية تطبيقات الويب.
+  tagline: تكوين جدار حماية تطبيقات الويب (WAF) والسياسات.
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -1,10 +1,8 @@
 ---
 title: WAF
-description: >-
-  Konfiguration und Richtlinien der Web Application Firewall für F5 Distributed
-  Cloud.
+description: Web-App-Firewall (WAF)-Konfiguration und Richtlinien für F5 Distributed Cloud.
 hero:
-  tagline: Konfiguration und Richtlinien der Web Application Firewall.
+  tagline: Web-App-Firewall (WAF)-Konfiguration und Richtlinien.
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: WAF
 description: >-
-  Configuración y políticas de firewall de aplicaciones web para F5 Distributed
+  Configuración del firewall de aplicaciones web y políticas para F5 Distributed
   Cloud.
 hero:
-  tagline: Configuración y políticas de firewall de aplicaciones web.
+  tagline: Configuración del firewall de aplicaciones web y políticas.
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: WAF
 description: >-
-  Configuration et politiques du pare-feu d'application web pour F5 Distributed
+  Configuration du pare-feu applicatif web et politiques pour F5 Distributed
   Cloud.
 hero:
-  tagline: Configuration et politiques du pare-feu d'application web.
+  tagline: Configuration du pare-feu applicatif web et politiques.
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -1,10 +1,8 @@
 ---
 title: WAF
-description: >-
-  F5 डिस्ट्रीब्यूटेड क्लाउड के लिए वेब एप्लिकेशन फ़ायरवॉल कॉन्फ़िगरेशन और
-  नीतियाँ।
+description: F5 Distributed Cloud के लिए वेब ऐप्लिकेशन फ़ायरवॉल कॉन्फ़िगरेशन और नीतियाँ।
 hero:
-  tagline: वेब एप्लिकेशन फ़ायरवॉल कॉन्फ़िगरेशन और नीतियाँ।
+  tagline: वेब ऐप्लिकेशन फ़ायरवॉल कॉन्फ़िगरेशन और नीतियाँ।
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: WAF
 description: >-
-  Configurazione e policy del firewall per applicazioni web per F5 Distributed
-  Cloud.
+  Configurazione del firewall per applicazioni web (WAF) e policy per F5
+  Distributed Cloud.
 hero:
-  tagline: Configurazione e policy del firewall per applicazioni web.
+  tagline: Configurazione del firewall per applicazioni web (WAF) e policy.
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: WAF
-description: F5 Distributed CloudのWebアプリケーションファイアウォールの設定とポリシー。
+description: F5 Distributed Cloud の Web アプリファイアウォール (WAF) の設定とポリシー。
 hero:
-  tagline: Webアプリケーションファイアウォールの設定とポリシー。
+  tagline: Web アプリファイアウォール (WAF) の設定とポリシー。
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: WAF
-description: F5 Distributed Cloud를 위한 웹 애플리케이션 방화벽 구성 및 정책.
+description: F5 Distributed Cloud의 웹 앱 방화벽 (WAF) 구성 및 정책.
 hero:
-  tagline: 웹 애플리케이션 방화벽 구성 및 정책.
+  tagline: 웹 앱 방화벽 (WAF) 구성 및 정책.
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: WAF
 description: >-
-  Configuração e políticas de firewall de aplicação web para F5 Distributed
+  Configuração de firewall de aplicações web e políticas para F5 Distributed
   Cloud.
 hero:
-  tagline: Configuração e políticas de firewall de aplicação web.
+  tagline: Configuração de firewall de aplicações web e políticas.
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: WAF
-description: การกำหนดค่าไฟร์วอลล์แอปพลิเคชันเว็บและนโยบายสำหรับ F5 Distributed Cloud
+description: การกำหนดค่าไฟร์วอลล์แอปเว็บและนโยบายสำหรับ F5 Distributed Cloud
 hero:
-  tagline: การกำหนดค่าไฟร์วอลล์แอปพลิเคชันเว็บและนโยบาย
+  tagline: การกำหนดค่าไฟร์วอลล์แอปเว็บและนโยบาย
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: WAF
-description: F5 分布式云的 Web 应用防火墙配置与策略。
+description: F5 Distributed Cloud 的 Web 应用防火墙配置与策略。
 hero:
   tagline: Web 应用防火墙配置与策略。
   image:

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: WAF
-description: F5 Distributed Cloud 的網頁應用程式防火牆配置與策略。
+description: F5 Distributed Cloud 的網路應用程式防火牆配置與策略。
 hero:
-  tagline: 網頁應用程式防火牆配置與策略。
+  tagline: 網路應用程式防火牆配置與策略。
   image:
     html: <img src="/waf/images/hero.svg" alt="F5 XC WAF" />
 sidebar:


### PR DESCRIPTION
## Summary
- Re-translated all locale files using docs-theme v3.5.5 glossary translator
- Product names now consistently translated using authoritative terms from mega-menu-translations.ts

Closes #478

## Test plan
- [ ] CI passes
- [ ] GitHub Pages deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)