### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -13,7 +13,7 @@
     "terraform-provider-xcsh": [".github/workflows/translation-audit.yml", "scripts/locale-lint.sh"],
     "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini"],
-    "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
     "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
   },
   "protected_files": [


### PR DESCRIPTION
Closes #564

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .claude/governance.json