### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,9 +169,9 @@ repos:
         types: [text]
         # codespell's own `skip` list only applies during its directory
         # traversal; when pre-commit passes explicit file paths it is bypassed.
-        # Filter translation dirs here so their foreign-language words
-        # (e.g. German "Referenz") never reach codespell. See issue #579.
-        exclude: ^docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/
+        # Filter translation docs and source catalogs here so their
+        # foreign-language words never reach codespell. See issues #579 and #934.
+        exclude: ^(docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|src/i18n/.*translations)
 
   # ===========================================================================
   # EditorConfig conformance — config: .editorconfig-checker.json


### PR DESCRIPTION
Closes #671

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .pre-commit-config.yaml