### PR TITLE
chore(governance): bootstrap exact managed callers

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -253,7 +253,7 @@ jobs:
   enforce-settings:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@69ad2be64ca4c2b0e608bef54a867d3820fa0311
+    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@94a0cb518b88f717e7b452a714fe7f97a00d0bbb
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
     secrets:
@@ -262,7 +262,7 @@ jobs:
   sync-files:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@69ad2be64ca4c2b0e608bef54a867d3820fa0311
+    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@94a0cb518b88f717e7b452a714fe7f97a00d0bbb
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
       downstream_sha: ${{ github.sha }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@8eaaced5c8800da45934031b152c863ce8ee84c0
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@94a0cb518b88f717e7b452a714fe7f97a00d0bbb
     permissions:
       contents: read # checkout repository content in the reusable workflow
       packages: read # pull lint tooling from GitHub Packages


### PR DESCRIPTION
Installs the exact enforcement and Super-Linter callers before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.